### PR TITLE
Config changes

### DIFF
--- a/luapress/luapress.lua
+++ b/luapress/luapress.lua
@@ -23,6 +23,25 @@ local function build_index(pages, posts, templates)
     local index = 1
     local count = 0
     local output = ''
+    
+    -- Sticky top page  Have an index.html anyway.
+    if config.sticky_page then
+      local idxpagesticky
+      if config.index then
+	  -- use specified page
+	  for _, page in ipairs(pages) do
+	  if page.name == config.index then
+	      idxpagesticky = page
+	      break
+	  end
+      end
+      else
+        -- use first page
+        idxpagesticky = pages[1]
+      end
+      template:set('post', idxpagesticky)
+      output = output .. template:process(templates.post)
+    end
 
     for k, post in ipairs(posts) do
         -- Add post to output, increase count
@@ -305,6 +324,8 @@ local config = {
     more_separator = '',
     -- Select a page as the landing page (optional, no path or suffix)
     index = nil,
+    -- If there is a sticky top, then the landing page will be used on the index page above the posts
+    sticky_page = true,    
 }
 
 return config

--- a/luapress/luapress.lua
+++ b/luapress/luapress.lua
@@ -174,6 +174,7 @@ local function build()
     template:set('title', config.title)
     template:set('url', config.url)
     template:set('config', config)
+    if not config.archive_title then config.archive_title = 'Archive' end
 
     -- Load template files
     if config.print then print('[1] Loading templates') end
@@ -196,10 +197,10 @@ local function build()
     -- Build the archive page (all posts) if at least one post exists
     if #posts > 0 then
         template:set('posts', posts)
-        template:set('page', {title = 'Archive'})
+        template:set('page', {title = config.archive_title})
         table.insert(pages, {
-            link = 'Archive' .. (config.link_dirs and '' or '.html'),
-            title = 'Archive',
+            link = 'archive' .. (config.link_dirs and '' or '.html'),
+            title = config.archive_title,
             time = os.time(),
             content = template:process(templates.archive),
             template = 'page',
@@ -326,6 +327,8 @@ local config = {
     index = nil,
     -- If there is a sticky top, then the landing page will be used on the index page above the posts
     sticky_page = true,    
+    -- Post archive title
+    archive_title = 'Archive',
 }
 
 return config

--- a/plugins/gallery/init.lua
+++ b/plugins/gallery/init.lua
@@ -159,7 +159,7 @@ local function process(page, arg)
     -- build index (HTML code that replaces the plugin call)
     local tbl = {}
     for i, img in ipairs(images) do
-	tbl[#tbl + 1] = string.format("<a href=\"%s\"><img src=\"%s\"></a>\n",
+	tbl[#tbl + 1] = string.format("<a href=\"%s\"><img src=\"%s\" /></a>\n",
 	    config.url .. "/gallery/" .. img.subdir .. "/" .. img.htmlbase,
 	    config.url .. "/gallery/" .. img.subdir .. "/thumbs/" .. img.imgname)
     end


### PR DESCRIPTION
This pull request implements two features:
- the first is to have an option to make the landing page a sticky top post; so you can have a little text that describes the main topic of your site, with below it the latests posts.
- the second is an option to configure the title of the archive overview; it still uses the name Archive.lhtml for the template html file.
