### PR TITLE
added support for functions and tables in markdown

### DIFF
--- a/luapress/util.lua
+++ b/luapress/util.lua
@@ -148,7 +148,25 @@ local function _process_content(s, item)
     -- Set $=key's
     s = s:gsub('%$=url', config.url)
 
-    -- Get $key=value's (and remove from string)
+	-- Fetch key data from the posts. There are 3 variations on the key syntax:
+	-- The first version is $key=L'code' for defining lua functions
+	-- The second is $key=L{fields} for defining lua tables
+	-- The last is $key=value
+	-- Nota bene:
+	-- All matches are removed from 's' afterwards
+	-- Variations one and two can span multiple lines
+	-- Quotes do NOT have to be escaped when defining functions
+	-- Now, starting with code...
+    for k, v in s:gmatch('%$([%w]+)=L\'(.-)\'\n') do
+        item[k] = assert(loadstring('return '.. v))()
+    end
+	s = s:gsub('%$[%w]+=L\'.-\'\n', '')
+	-- ...then fields...
+    for k, v in s:gmatch('%$([%w]+)=L(%b{})\n') do
+        item[k] = assert(loadstring('return {'.. v ..'}'))()
+	end
+	s = s:gsub('%$[%w]+=L%b{}\n', '')
+	--Last, values...
     for k, v in s:gmatch('%$([%w]+)=(.-)\n') do
         item[k] = v
     end


### PR DESCRIPTION
According to lustache there are many fun things that we can do with the templates, such as functions and tables: https://github.com/Olivine-Labs/lustache/blob/master/README.md

Except for this:
https://github.com/Fizzadar/Luapress/blob/develop/luapress/util.lua#L152

Now I don't claim to be a smart man or anything, but I'm pretty sure that's just reading everything in as a string. The fix involved extending the syntax of markdown a bit more, and the results are overall pretty great. You can do a lot more with lustache now.

There are some caveats though:
https://github.com/Olivine-Labs/lustache/blob/master/spec/render_spec.lua#L149

At least these last two cases fail for no apparent reason when tried in luapress. I suspect something far more foul and malignant is the reason for this, but I'm not interested in digging deeper.

Your turn.
