### PR TITLE
BugFix: use gsub get link is null and change link to fname

### DIFF
--- a/luapress/util.lua
+++ b/luapress/util.lua
@@ -202,6 +202,9 @@ local function load_markdowns(directory, template)
 
             -- Work out link
             local link = fname:gsub(' ', '_'):gsub('[^_aA-zZ0-9]', '')
+            if string.len(link) == 0 then
+              link = fname
+            end
             if not config.link_dirs then
                 link = link .. '.html'
             end


### PR DESCRIPTION
```
I use `Chinese` character as `post` or `pages`  link, I found gsub`s result is null

eg:

fname = "你好"
local link = fname:gsub(' ', '_'):gsub('[^_aA-zZ0-9]', '')
assert(string.len(link) == 0)

```
