### PR TITLE
[lhtml] Fix usage of break, avoid string creation

### DIFF
--- a/luapress/template.lua
+++ b/luapress/template.lua
@@ -70,6 +70,9 @@ function process_lhtml(code)
         '<%?=(.-)%?>',
         ']] .. self.tostring( %1 ) .. [['
     )
+    
+    -- Replace ?>  <? spaces and lines between lua codes
+    code = code:gsub('%?>[ \n]*<%?', '\n')
 
     -- Replace <? to close output, start raw lua
     code = code:gsub('<%?%s', ']] ')


### PR DESCRIPTION
<? local allMarked = true ?>
  <? for index, data in ipairs(circuit.thermalRatings) do ?>
      <? if not data.marked then ?>
          <? allMarked = false ?>
          <? break ?>
       <? end ?>
<? end ?>

I often create lhtml code like this, however it does not work due to break.
This code is parsed as something like this:

for ... do
    output = output .. [[      ]]
    if x then
        output = output .. [[      ]]
        break
        output = output .. [[      ]] -- Error here, doesnt make sense to call this after break.
    end
    output = output .. [[      ]]
end

It also solves a memory issue. 
`output = output .. [[      ]]`

This allocates a new string that has absolute no use.
After garbage collection everything is cleaned, but meanwhile I got up to 1.5GB of memory usage with not so huge output.
