### PR TITLE
Fixed copying template directory on Windows

### DIFF
--- a/luapress/luapress.lua
+++ b/luapress/luapress.lua
@@ -340,8 +340,9 @@ local function make_skeleton(root, url, use_lhtml)
     end
 
     -- Copy the default template
-    local base = string.gsub(arg[0], "/[^/]-/[^/]-$", "")
-    util.copy_dir(base .. '/template/' .. template_type .. '/', root .. '/templates/default/')
+    local directory = arg[0] .. '/../../template/' .. template_type .. '/'
+    local destination = root .. '/templates/default/'
+    util.copy_dir(directory, destination)
 
     local attributes = lfs.attributes(root .. '/config.lua')
     if attributes then


### PR DESCRIPTION
Luapress was not working correctly on Windows because the pattern `"/[^/]-/[^/]-$"`, used to 'go back' by two directories, assumes forward slashes in the filepath, whereas Windows commonly uses backslashes too.

Turns out LFS will happily resolve `..` in filepaths, so using gsub for find/replace is not needed - we can just add`/../..` to the path and LFS will do the work.