### PR TITLE
Modified `package.path` in `bin/luapress` to ensure builds in Win 10

### DIFF
--- a/bin/luapress
+++ b/bin/luapress
@@ -124,6 +124,10 @@ else
         end
     end
 
+    -- Add current path to package.path to ensure Windows will load config.lua
+    -- Must follow this order, to avoid problems with luapress.default_config
+    package.path = package.path..";"..lfs.currentdir()..'/config.lua'
+
     -- Ensure local config file
     local _, err = io.open('config.lua', 'r')
     if err then


### PR DESCRIPTION
Hi! I added this before `-- Ensure local config file`:

```
    -- Add current path to package.path to ensure Windows will load config.lua
    -- Must follow this order, to avoid problems with luapress.default_config
    package.path = package.path..";"..lfs.currentdir()..'/config.lua'
```

This is mostly an empirical solution, since I was having problems building projects with LuaPress on Windows 10.

Without this change in `package.path`, executing `luapress` to build a project results in this:

```
E:\Fabio\Desktop\sample.org.br
λ luapress dev
### Luapress v3.4

D:\Libraries\Lua\5.1\lua.exe: ...stree\lib\luarocks\rocks\luapress\3.4-0\bin\luapress:135: module 'config' not found:No LuaRocks module found for config
        no field package.preload['config']
        no file 'C:\Users\fabio\AppData\Roaming/luarocks/share/lua/5.1/config.lua'
        no file 'C:\Users\fabio\AppData\Roaming/luarocks/share/lua/5.1/config/init.lua'
        no file 'D:\Libraries\Lua\5.1\systree/share/lua/5.1/config.lua'
        no file 'D:\Libraries\Lua\5.1\systree/share/lua/5.1/config/init.lua'
        no file 'D:\Libraries\LuaRocks/lua/config.lua'
        no file 'D:\Libraries\Lua\5.1\lua\config.luac'
        no file 'D:\Libraries\LuaRocks\lua\config.lua'
        no file 'D:\Libraries\LuaRocks\lua\config\init.lua'
        no file 'C:\Users\fabio\AppData\Roaming\LuaRocks\share\lua\5.1\config.lua'
        no file 'C:\Users\fabio\AppData\Roaming\LuaRocks\LuaRocks\share\lua\5.1\config\init.lua'
        no file 'D:\Libraries\Lua\5.1\systree\share\lua\5.1\config.lua'
        no file 'D:\Libraries\Lua\5.1\systree\share\lua\5.1\config\init.lua'
        no file 'C:\Users\fabio\AppData\Roaming/luarocks/lib/lua/5.1/config.dll'
        no file 'D:\Libraries\Lua\5.1\systree/lib/lua/5.1/config.dll'
        no file 'C:\Users\fabio\AppData\Roaming\LuaRocks\lib\lua\5.1\config.dll'
        no file 'D:\Libraries\Lua\5.1\systree\lib\lua\5.1\config.dll'
stack traceback:
        [C]: in function 'require'
        ...stree\lib\luarocks\rocks\luapress\3.4-0\bin\luapress:135: in main chunk
        [C]: ?
```

I checked to see if this change would break something under Linux, but I tested it in Raspbian only, and it did not affect the build.

Cheers! 😉